### PR TITLE
Update lancache-uplay.conf

### DIFF
--- a/etc/nginx/sites-available/lancache-uplay.conf
+++ b/etc/nginx/sites-available/lancache-uplay.conf
@@ -15,6 +15,7 @@ server {
         # range to keep single downloads quick and hence ensure
         # interactivity is good.
         proxy_bind lc-host-proxybind;
+        proxy_ignore_headers Expires Cache-Control;
         #testing cache of 200 value
         #proxy_cache_valid 200 90d; proxy_cache_valid 206 90d;
         proxy_cache uplay;


### PR DESCRIPTION
chong601 -- I tested latest Lancache configs on my server and noticed that Uplay is bypassing caches (download goes through NGINX, but it is not stored to disk).

Adding proxy_ignore_headers Expires Cache-Control; solves this issue.